### PR TITLE
feat: add FlowingLiquids dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -14,6 +14,7 @@
         { "id": "CoreWorlds", "minVersion": "1.1.0" },
         { "id": "EdibleSubstance", "minVersion": "1.0.0" },
         { "id": "EventualSkills", "minVersion": "1.0.0" },
+        { "id": "FlowingLiquids", "minVersion": "1.3.0" },
         { "id": "Hunger", "minVersion": "1.1.0" },
         { "id": "InGameHelp", "minVersion": "1.1.0" },
         { "id": "InGameHelpAPI", "minVersion": "1.0.0" },


### PR DESCRIPTION
Caves has now been updated so that it no longer causes problems with oceans being created in an unstable state. Fluid and Machines already have an optional FlowingLiquids dependency, so all the necessary integrations already exist, it just needs to be activated.