### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/joshariasSurvival/world/ForagableFoodProvider.java
+++ b/src/main/java/org/terasology/joshariasSurvival/world/ForagableFoodProvider.java
@@ -108,9 +108,9 @@ public class ForagableFoodProvider extends SurfaceObjectProvider<Biome, Foragabl
         this.configuration = (ForagableFoodDensityConfiguration) configuration;
     }
 
-    private static class ForagableFoodDensityConfiguration implements Component<ForagableFoodDensityConfiguration> {
+    public static class ForagableFoodDensityConfiguration implements Component<ForagableFoodDensityConfiguration> {
         @Range(min = 0, max = 1.0f, increment = 0.05f, precision = 2, description = "Define the overall amount of foragable food")
-        private float density = 0.4f;
+        public float density = 0.4f;
 
         @Override
         public void copyFrom(ForagableFoodDensityConfiguration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191